### PR TITLE
Feature/#63 feat ticket concurrency control

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/onevoice/common/config/autoConfig/FeignSecurityHeaderConfig.java
+++ b/common/src/main/java/com/onevoice/common/config/autoConfig/FeignSecurityHeaderConfig.java
@@ -1,4 +1,4 @@
-package com.onevoice.common.config;
+package com.onevoice.common.config.autoConfig;
 
 
 import feign.RequestInterceptor;

--- a/common/src/main/java/com/onevoice/common/config/autoConfig/SwaggerConfig.java
+++ b/common/src/main/java/com/onevoice/common/config/autoConfig/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.onevoice.common.config;
+package com.onevoice.common.config.autoConfig;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/common/src/main/java/com/onevoice/common/config/autoConfig/audit/JpaAuditingConfig.java
+++ b/common/src/main/java/com/onevoice/common/config/autoConfig/audit/JpaAuditingConfig.java
@@ -1,6 +1,7 @@
-package com.onevoice.common.config.audit;
+package com.onevoice.common.config.autoConfig.audit;
 
 
+import com.onevoice.common.config.audit.AuditorAwareImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;

--- a/common/src/main/java/com/onevoice/common/config/manualConfig/RedisSupportFactory.java
+++ b/common/src/main/java/com/onevoice/common/config/manualConfig/RedisSupportFactory.java
@@ -1,0 +1,21 @@
+package com.onevoice.common.config.manualConfig;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+public class RedisSupportFactory {
+
+    public static RedisConnectionFactory redisConnectionFactory(String host, int port) {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    public static RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/common/src/main/java/com/onevoice/common/config/manualConfig/RedissonSupportFactory.java
+++ b/common/src/main/java/com/onevoice/common/config/manualConfig/RedissonSupportFactory.java
@@ -1,0 +1,17 @@
+package com.onevoice.common.config.manualConfig;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+public class RedissonSupportFactory {
+
+    public static RedissonClient create(String host, int port) {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress("redis://" + host + ":" + port)
+            .setConnectionMinimumIdleSize(5)
+            .setConnectionPoolSize(10);
+        return Redisson.create(config);
+    }
+}

--- a/common/src/main/java/com/onevoice/common/dto/ResponseCode.java
+++ b/common/src/main/java/com/onevoice/common/dto/ResponseCode.java
@@ -64,7 +64,9 @@ public enum ResponseCode {
     TICKET_OWNER_MISS__MATCH(4530, HttpStatus.FORBIDDEN, "티켓의 소유자가 일치하지 않습니다."),
     TICKET_NOT_FOUND(4540, HttpStatus.NOT_FOUND, "티켓을 찾을 수 없습니다."),
     TICKET_REMOTE_USER_NOT_FOUND(4541, HttpStatus.NOT_FOUND, "해탕 티켓을 소유한 유저가 없습니다."),
-    Ticket_SESSION_NOT_FOUND(4543, HttpStatus.NOT_FOUND, "해당 공연 회차가 없습니다."),
+    TICKET_SESSION_NOT_FOUND(4543, HttpStatus.NOT_FOUND, "해당 공연 회차가 없습니다."),
+    DUPLICATE_TICKET_EXCEPTION(4590, HttpStatus.CONFLICT, "이미 예매된 티켓입니다."),
+
 
     //Seat (B = 6)
     SEAT_NOT_FOUND(4640, HttpStatus.NOT_FOUND, "존재하지 않는 좌석입니다."),

--- a/common/src/main/java/com/onevoice/common/enumtype/SeatStatus.java
+++ b/common/src/main/java/com/onevoice/common/enumtype/SeatStatus.java
@@ -1,4 +1,4 @@
-package com.onevoice.seat.domain;
+package com.onevoice.common.enumtype;
 
 public enum SeatStatus {
     AVAILABLE, HOLD, RESERVED

--- a/common/src/main/java/com/onevoice/common/enumtype/TicketStatus.java
+++ b/common/src/main/java/com/onevoice/common/enumtype/TicketStatus.java
@@ -1,10 +1,8 @@
-package com.onevoice.ticket.domain;
+package com.onevoice.common.enumtype;
 
 public enum TicketStatus {
-
     WAITING_PAYMENT,
     CONFIRM_PAYMENT,
     CANCELLED,
     EXPIRED;
-
 }

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,3 @@
-com.onevoice.common.config.SwaggerConfig
-com.onevoice.common.config.FeignSecurityHeaderConfig
-com.onevoice.common.config.audit.JpaAuditingConfig
+com.onevoice.common.config.autoConfig.SwaggerConfig
+com.onevoice.common.config.autoConfig.FeignSecurityHeaderConfig
+com.onevoice.common.config.autoConfig.audit.JpaAuditingConfig

--- a/config/src/main/resources/config-repo/ticket-service.yml
+++ b/config/src/main/resources/config-repo/ticket-service.yml
@@ -17,6 +17,17 @@ spring:
     show-sql: true
     open-in-view: false
 
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      group-id: ticket-group
+      auto-offset-reset: earliest
+
   zipkin:
     base-url: http://zipkin:9411  # 도커 내부 서비스명 사용
     enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,18 @@ services:
     networks:
       - monitoring
 
+  kafka-exporter:
+    image: danielqsj/kafka-exporter:latest
+    container_name: kafka-exporter
+    ports:
+      - "9308:9308"
+    environment:
+      KAFKA_URI: kafka:29092
+    depends_on:
+      - kafka
+    networks:
+      - monitoring
+
 volumes:
   grafana-storage:
   prometheus-data:

--- a/payment/src/main/java/com/onevoice/payment/application/dto/client/FindTicketResponseDto.java
+++ b/payment/src/main/java/com/onevoice/payment/application/dto/client/FindTicketResponseDto.java
@@ -1,5 +1,6 @@
 package com.onevoice.payment.application.dto.client;
 
+import com.onevoice.common.enumtype.TicketStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -13,12 +14,4 @@ public record FindTicketResponseDto(
     TicketStatus status,
     LocalDateTime reservedAt
 ) {
-
-    public enum TicketStatus {
-
-        WAITING_PAYMENT,
-        CONFIRM_PAYMENT,
-        CANCELLED,
-        FAILED;
-    }
 }

--- a/payment/src/main/java/com/onevoice/payment/application/dto/client/UpdateTicketStatusRequestDto.java
+++ b/payment/src/main/java/com/onevoice/payment/application/dto/client/UpdateTicketStatusRequestDto.java
@@ -1,14 +1,8 @@
 package com.onevoice.payment.application.dto.client;
 
+import com.onevoice.common.enumtype.TicketStatus;
+
 public record UpdateTicketStatusRequestDto(
     TicketStatus status
 ) {
-
-    public enum TicketStatus {
-
-        WAITING_PAYMENT,
-        CONFIRM_PAYMENT,
-        CANCELLED,
-        EXPIRED;
-    }
 }

--- a/payment/src/main/java/com/onevoice/payment/application/dto/message/TicketMessage.java
+++ b/payment/src/main/java/com/onevoice/payment/application/dto/message/TicketMessage.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record TicketMessage(
     UUID ticketId,
+    UUID userId,
     TicketStatus ticketStatus
 ) {
 }

--- a/payment/src/main/java/com/onevoice/payment/infrastructure/message/PaymentEventListener.java
+++ b/payment/src/main/java/com/onevoice/payment/infrastructure/message/PaymentEventListener.java
@@ -35,7 +35,7 @@ public class PaymentEventListener {
 //            new UpdateTicketStatusRequestDto(TicketStatus.CONFIRM_PAYMENT));
         String message = objectMapper.writeValueAsString(event.getMessage());
         String ticketStatus = getTicketStatus(
-            event.getMessage().ticketId(),
+            event.getMessage().ticketId(),event.getMessage().userId(),
             TicketStatus.CONFIRM_PAYMENT
         );
         // key 는 지정하지 않아도 된다.
@@ -52,16 +52,16 @@ public class PaymentEventListener {
 //            event.getMessage().ticketId(),
 //            new UpdateTicketStatusRequestDto(TicketStatus.CANCELLED));
         String ticketStatus = getTicketStatus(
-            event.getMessage().ticketId(),
+            event.getMessage().ticketId(),event.getMessage().userId(),
             TicketStatus.CANCELLED
         );
         kafkaTemplate.send("ticket_status", ticketStatus);
     }
 
-    private String getTicketStatus(UUID ticketId, TicketStatus cancelled)
+    private String getTicketStatus(UUID ticketId,UUID userId ,TicketStatus cancelled)
         throws JsonProcessingException {
         return objectMapper.writeValueAsString(
-            new TicketMessage(ticketId,
+            new TicketMessage(ticketId,userId,
                 cancelled)
         );
     }

--- a/payment/src/main/java/com/onevoice/payment/infrastructure/message/PaymentEventListener.java
+++ b/payment/src/main/java/com/onevoice/payment/infrastructure/message/PaymentEventListener.java
@@ -2,9 +2,9 @@ package com.onevoice.payment.infrastructure.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onevoice.common.enumtype.TicketStatus;
 import com.onevoice.payment.application.client.TicketClient;
 import com.onevoice.payment.application.dto.message.TicketMessage;
-import com.onevoice.payment.application.dto.message.TicketMessage.TicketStatus;
 import com.onevoice.payment.application.event.PaymentCreateEvent;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -51,3 +51,7 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: [ 'host.docker.internal:8009' ]
+
+  - job_name: 'kafka-exporter'
+    static_configs:
+        - targets: [ 'kafka-exporter:9308' ]

--- a/seat/src/main/java/com/onevoice/seat/application/service/SeatService.java
+++ b/seat/src/main/java/com/onevoice/seat/application/service/SeatService.java
@@ -1,8 +1,8 @@
 package com.onevoice.seat.application.service;
 
+import com.onevoice.common.enumtype.SeatStatus;
 import com.onevoice.seat.application.dto.CreateSeatCommand;
 import com.onevoice.seat.application.dto.HoldSeatCommand;
-import com.onevoice.seat.domain.SeatStatus;
 import com.onevoice.seat.presentation.dto.response.HoldSeatResponseDto;
 import com.onevoice.seat.presentation.dto.response.SeatCreateResponseDto;
 import com.onevoice.seat.presentation.dto.response.SeatResponseDto;

--- a/seat/src/main/java/com/onevoice/seat/application/service/SeatServiceImpl.java
+++ b/seat/src/main/java/com/onevoice/seat/application/service/SeatServiceImpl.java
@@ -1,5 +1,6 @@
 package com.onevoice.seat.application.service;
 
+import com.onevoice.common.enumtype.SeatStatus;
 import com.onevoice.seat.application.dto.CreateSeatCommand;
 import com.onevoice.seat.application.dto.HoldSeatCommand;
 import com.onevoice.seat.exception.SeatAlreadyHeldException;
@@ -8,7 +9,6 @@ import com.onevoice.seat.presentation.dto.response.HoldSeatResponseDto;
 import com.onevoice.seat.presentation.dto.response.SeatCreateResponseDto;
 import com.onevoice.seat.presentation.dto.response.SeatResponseDto;
 import com.onevoice.seat.domain.Seat;
-import com.onevoice.seat.domain.SeatStatus;
 import com.onevoice.seat.domain.repository.SeatRepository;
 import com.onevoice.seat.domain.vo.Money;
 import com.onevoice.seat.domain.vo.SeatCode;

--- a/seat/src/main/java/com/onevoice/seat/domain/Seat.java
+++ b/seat/src/main/java/com/onevoice/seat/domain/Seat.java
@@ -1,6 +1,7 @@
 package com.onevoice.seat.domain;
 
 import com.onevoice.common.entity.BaseEntity;
+import com.onevoice.common.enumtype.SeatStatus;
 import com.onevoice.seat.domain.vo.Money;
 import com.onevoice.seat.domain.vo.SeatCode;
 import com.onevoice.seat.domain.vo.SessionId;

--- a/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
+++ b/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
@@ -1,10 +1,9 @@
 package com.onevoice.seat.presentation;
 
-import com.onevoice.common.dto.CommonResponse;
+import com.onevoice.common.enumtype.SeatStatus;
 import com.onevoice.seat.application.dto.CreateSeatCommand;
 import com.onevoice.seat.application.dto.HoldSeatCommand;
 import com.onevoice.seat.application.service.SeatService;
-import com.onevoice.seat.domain.SeatStatus;
 import com.onevoice.seat.presentation.dto.request.CreateSeatRequestDto;
 import com.onevoice.seat.presentation.dto.request.HoldSeatRequestDto;
 import com.onevoice.seat.presentation.dto.request.SeatStatusChangeRequestDto;
@@ -13,8 +12,6 @@ import com.onevoice.seat.presentation.dto.response.SeatCreateResponseDto;
 import com.onevoice.seat.presentation.dto.response.SeatResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
+++ b/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
@@ -73,7 +73,9 @@ public class SeatInternalController {
     * */
     @PutMapping("/status")
     public Optional<List<SeatResponseDto>> updateStatusInternal(
+            @RequestHeader("X-User-Id") UUID userId,
             @RequestBody SeatStatusChangeRequestDto request
+
     ) {
         List<SeatResponseDto> updatedSeats = seatService.updateSeatStatuses(
                 request.seatIds(), request.newStatus()
@@ -86,6 +88,7 @@ public class SeatInternalController {
     * */
     @PutMapping("/recover")
     public Optional<List<SeatResponseDto>> recoverSeats(
+            @RequestHeader("X-User-Id") UUID userId,
             @RequestBody List<UUID> seatIds
     ) {
         List<SeatResponseDto> recovered = seatService.updateSeatStatuses(seatIds, SeatStatus.AVAILABLE);

--- a/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
+++ b/seat/src/main/java/com/onevoice/seat/presentation/SeatInternalController.java
@@ -1,6 +1,7 @@
 package com.onevoice.seat.presentation;
 
 import com.onevoice.common.enumtype.SeatStatus;
+import com.onevoice.common.security.UserRole;
 import com.onevoice.seat.application.dto.CreateSeatCommand;
 import com.onevoice.seat.application.dto.HoldSeatCommand;
 import com.onevoice.seat.application.service.SeatService;
@@ -74,6 +75,7 @@ public class SeatInternalController {
     @PutMapping("/status")
     public Optional<List<SeatResponseDto>> updateStatusInternal(
             @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") UserRole userRole,
             @RequestBody SeatStatusChangeRequestDto request
 
     ) {

--- a/seat/src/main/java/com/onevoice/seat/presentation/dto/request/SeatStatusChangeRequestDto.java
+++ b/seat/src/main/java/com/onevoice/seat/presentation/dto/request/SeatStatusChangeRequestDto.java
@@ -1,7 +1,6 @@
 package com.onevoice.seat.presentation.dto.request;
 
-import com.onevoice.seat.domain.SeatStatus;
-
+import com.onevoice.common.enumtype.SeatStatus;
 import java.util.List;
 import java.util.UUID;
 

--- a/ticket/build.gradle
+++ b/ticket/build.gradle
@@ -16,4 +16,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
+
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 }

--- a/ticket/src/main/java/com/onevoice/ticket/application/client/SeatClient.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/client/SeatClient.java
@@ -1,5 +1,6 @@
 package com.onevoice.ticket.application.client;
 
+import com.onevoice.common.security.UserRole;
 import com.onevoice.ticket.application.dto.FindHoldSeatQuery;
 import com.onevoice.ticket.application.dto.FindSeatQuery;
 import com.onevoice.ticket.application.dto.HoldSeatCommand;
@@ -11,6 +12,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "seat-service")
 public interface SeatClient {
@@ -23,6 +25,8 @@ public interface SeatClient {
 
     @PutMapping("/internal/status")
     Optional<List<FindSeatQuery>> updateStatusInternal(
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestHeader("X-User-Role") UserRole userRole,
         @RequestBody UpdateSeatStatusCommand command
     );
 }

--- a/ticket/src/main/java/com/onevoice/ticket/application/client/SeatClient.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/client/SeatClient.java
@@ -1,7 +1,10 @@
 package com.onevoice.ticket.application.client;
 
 import com.onevoice.ticket.application.dto.FindHoldSeatQuery;
+import com.onevoice.ticket.application.dto.FindSeatQuery;
 import com.onevoice.ticket.application.dto.HoldSeatCommand;
+import com.onevoice.ticket.application.dto.UpdateSeatStatusCommand;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -16,5 +19,10 @@ public interface SeatClient {
     Optional<FindHoldSeatQuery> holdSeatsInternal(
         @PathVariable UUID sessionId,
         @RequestBody HoldSeatCommand command
+    );
+
+    @PutMapping("/internal/status")
+    Optional<List<FindSeatQuery>> updateStatusInternal(
+        @RequestBody UpdateSeatStatusCommand command
     );
 }

--- a/ticket/src/main/java/com/onevoice/ticket/application/dto/FindSeatQuery.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/dto/FindSeatQuery.java
@@ -1,0 +1,13 @@
+package com.onevoice.ticket.application.dto;
+
+import java.util.UUID;
+
+public record FindSeatQuery(
+    UUID seatId,
+    UUID sessionId,
+    String seatCode,
+    String status,
+    int price
+) {
+
+}

--- a/ticket/src/main/java/com/onevoice/ticket/application/dto/TicketMessage.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/dto/TicketMessage.java
@@ -1,4 +1,4 @@
-package com.onevoice.payment.application.dto.message;
+package com.onevoice.ticket.application.dto;
 
 import com.onevoice.common.enumtype.TicketStatus;
 import java.util.UUID;
@@ -7,4 +7,5 @@ public record TicketMessage(
     UUID ticketId,
     TicketStatus ticketStatus
 ) {
+
 }

--- a/ticket/src/main/java/com/onevoice/ticket/application/dto/UpdateSeatStatusCommand.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/dto/UpdateSeatStatusCommand.java
@@ -1,0 +1,11 @@
+package com.onevoice.ticket.application.dto;
+
+import com.onevoice.common.enumtype.SeatStatus;
+import java.util.List;
+import java.util.UUID;
+
+public record UpdateSeatStatusCommand(
+    List<UUID> seatIds,
+    SeatStatus newStatus
+) {
+}

--- a/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
@@ -1,15 +1,17 @@
 package com.onevoice.ticket.application.service;
 
+import com.onevoice.common.enumtype.SeatStatus;
+import com.onevoice.common.enumtype.TicketStatus;
 import com.onevoice.ticket.application.client.SeatClient;
 import com.onevoice.ticket.application.client.ShowClient;
 import com.onevoice.ticket.application.client.UserClient;
-import com.onevoice.ticket.application.dto.FindHoldSeatQuery;
 import com.onevoice.ticket.application.dto.FindUserQuery;
 import com.onevoice.ticket.application.dto.HoldSeatCommand;
 import com.onevoice.ticket.application.dto.SessionDetailsQuery;
+import com.onevoice.ticket.application.dto.UpdateSeatStatusCommand;
 import com.onevoice.ticket.domain.Ticket;
-import com.onevoice.ticket.domain.TicketStatus;
 import com.onevoice.ticket.domain.repository.TicketRepository;
+import com.onevoice.ticket.exception.DuplicateTicketException;
 import com.onevoice.ticket.exception.RemoteUserNotFoundException;
 import com.onevoice.ticket.exception.TicketNotFoundException;
 import com.onevoice.ticket.exception.TicketOwnerMismatchException;
@@ -25,10 +27,13 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,33 +46,48 @@ public class TicketServiceImpl implements TicketService{
     private final UserClient userClient;
     private final ShowClient showClient;
     private final SeatClient seatClient;
+    private final RedissonClient redissonClient;
 
     @Override
     public CreateTicketResponseDto createTicket(CreateTicketRequestDto requestDto) {
 
-        FindUserQuery userQuery = userClient.findUserById(requestDto.userId()).orElseThrow(RemoteUserNotFoundException::new);
-        String userName = userQuery.email();
+        try {
 
-        SessionDetailsQuery sessionquery = showClient.getSessionDetail(requestDto.sessionId())
-            .orElseThrow(TicketSessionNotFoundException::new);
-        String showName = sessionquery.showName();
+            // 1. 사용자 조회
+            FindUserQuery userQuery = userClient.findUserById(requestDto.userId())
+                .orElseThrow(RemoteUserNotFoundException::new);
+            String userName = userQuery.email();
 
-        //TODO 좌석 선점 가능 여부 확인
+            // 2. 세션 정보 조회
+            SessionDetailsQuery sessionQuery = showClient.getSessionDetail(requestDto.sessionId())
+                .orElseThrow(TicketSessionNotFoundException::new);
+            String showName = sessionQuery.showName();
 
-        List<UUID> seatIdList = new ArrayList<>();
-        seatIdList.add(requestDto.seatId());
-        HoldSeatCommand seatIds = new HoldSeatCommand(seatIdList);
+            // 3. 좌석 선점 요청
+            List<UUID> seatIdList = List.of(requestDto.seatId());
+            HoldSeatCommand holdCommand = new HoldSeatCommand(seatIdList);
 
-        FindHoldSeatQuery findHoldSeatQuery = seatClient.holdSeatsInternal(requestDto.sessionId(),
-            seatIds).orElseThrow();
+            seatClient.holdSeatsInternal(requestDto.sessionId(), holdCommand)
+                .orElseThrow(() -> new IllegalStateException("좌석 선점 실패"));
 
-        log.info("FindHoldSeatQuery seatCode: {}", findHoldSeatQuery.seatIds().get(0));
+            // 4. 티켓 저장
+            Ticket ticket = new Ticket(
+                requestDto.userId(),
+                userName,
+                requestDto.sessionId(),
+                showName,
+                requestDto.seatId()
+            );
+            Ticket saved = ticketRepository.save(ticket);
 
-        Ticket ticket = new Ticket(requestDto.userId(),userName, requestDto.sessionId(),showName,requestDto.seatId());
+            return CreateTicketResponseDto.of(saved);
 
-        Ticket saved = ticketRepository.save(ticket);
-
-        return CreateTicketResponseDto.of(saved);
+        }catch (DataIntegrityViolationException e){
+            if (e.getMessage().contains("uk_session_seat")) {
+                throw new DuplicateTicketException();
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -98,61 +118,97 @@ public class TicketServiceImpl implements TicketService{
     @Override
     @Transactional
     public FindTicketResponseDto updateTicketStatus(UUID ticketId, UUID userId, UpdateTicketStatusRequestDto requestDto) {
+        try {
+            Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(TicketNotFoundException::new);
 
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(TicketNotFoundException::new);
+            if (!ticket.getUserId().equals(userId)) {
+                throw new TicketOwnerMismatchException();
+            }
 
-        if (!ticket.getUserId().equals(userId)) {
+            TicketStatus newStatus = requestDto.status();
+            ticket.updateTicketStatus(newStatus);
 
-            throw new TicketOwnerMismatchException();
+            return FindTicketResponseDto.of(ticket);
+
+        } catch (ObjectOptimisticLockingFailureException e) {
+            // 다른 트랜잭션이 먼저 상태를 변경한 경우 발생
+            throw new IllegalStateException("다른 요청에서 이미 상태가 변경되었습니다. 다시 시도해주세요.");
         }
-
-        TicketStatus newStatus = requestDto.status();
-
-        ticket.updateTicketStatus(newStatus);
-
-        return FindTicketResponseDto.of(ticket);
     }
 
     @Override
     @Transactional
     public FindTicketResponseDto updateTicketStatus(UUID ticketID,
         UpdateTicketStatusRequestDto requestDto) {
+        try {
 
-        Ticket ticket = ticketRepository.findById(ticketID).orElseThrow(TicketNotFoundException::new);
+            Ticket ticket = ticketRepository.findById(ticketID).orElseThrow(TicketNotFoundException::new);
 
-        TicketStatus newStatus = requestDto.status();
-        if (newStatus == TicketStatus.CONFIRM_PAYMENT) {
-            // 결제 확정
+            TicketStatus newStatus = requestDto.status();
+            log.info("newStatus : {}",newStatus.toString());
 
-        }else{
-            // 결제 실패
+            // 상태가 이미 원하는 값이면 무시
+            if (ticket.getStatus() == newStatus) {
+                log.info("이미 처리된 메시지입니다. ticketId={}, status={}", ticket.getId(), ticket.getStatus());
+                FindTicketResponseDto.of(ticket);
+            }
 
+            if (newStatus == TicketStatus.CONFIRM_PAYMENT) {
+                List<UUID> seatIds = new ArrayList<>();
+                seatIds.add(ticket.getSeatId());
+
+                UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
+                    SeatStatus.RESERVED);
+                seatClient.updateStatusInternal(command);
+            }else{
+                List<UUID> seatIds = new ArrayList<>();
+                seatIds.add(ticket.getSeatId());
+
+                UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
+                    SeatStatus.AVAILABLE);
+                seatClient.updateStatusInternal(command);
+
+            }
+            ticket.updateTicketStatus(newStatus);
+            return FindTicketResponseDto.of(ticket);
         }
-
-        return FindTicketResponseDto.of(ticket);
+        catch (ObjectOptimisticLockingFailureException e) {
+            // 다른 트랜잭션이 먼저 상태를 변경한 경우 발생
+            throw new IllegalStateException("다른 요청에서 이미 상태가 변경되었습니다. 다시 시도해주세요.");
+        }
     }
 
     @Override
     @Transactional
     public FindTicketResponseDto expireTicket(UUID ticketId) {
 
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(TicketNotFoundException::new);
+        try {
+            Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(TicketNotFoundException::new);
 
-        TicketStatus newStatus = TicketStatus.EXPIRED;
-        ticket.updateTicketStatus(newStatus);
-        return FindTicketResponseDto.of(ticket);
+            ticket.updateTicketStatus(TicketStatus.EXPIRED);
+
+            return FindTicketResponseDto.of(ticket);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new IllegalStateException("다른 요청에서 티켓 상태가 변경되었습니다. 만료 처리가 실패했습니다.");
+        }
     }
 
     @Override
     @Transactional
     public DeleteTicketResponseDto deleteTicket(UUID ticketId) {
 
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(TicketNotFoundException::new);
+        try {
+            Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(TicketNotFoundException::new);
 
-        TicketStatus newStatus = TicketStatus.CANCELLED;
-        ticket.updateTicketStatus(newStatus);
+            ticket.updateTicketStatus(TicketStatus.CANCELLED);
 
-        return DeleteTicketResponseDto.of(ticket);
+            return DeleteTicketResponseDto.of(ticket);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new IllegalStateException("다른 요청에서 티켓 상태가 변경되었습니다. 삭제 처리에 실패했습니다.");
+        }
     }
 
     @Override

--- a/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
@@ -2,6 +2,7 @@ package com.onevoice.ticket.application.service;
 
 import com.onevoice.common.enumtype.SeatStatus;
 import com.onevoice.common.enumtype.TicketStatus;
+import com.onevoice.common.security.UserRole;
 import com.onevoice.ticket.application.client.SeatClient;
 import com.onevoice.ticket.application.client.ShowClient;
 import com.onevoice.ticket.application.client.UserClient;
@@ -46,7 +47,6 @@ public class TicketServiceImpl implements TicketService{
     private final UserClient userClient;
     private final ShowClient showClient;
     private final SeatClient seatClient;
-    private final RedissonClient redissonClient;
 
     @Override
     public CreateTicketResponseDto createTicket(CreateTicketRequestDto requestDto) {
@@ -160,14 +160,15 @@ public class TicketServiceImpl implements TicketService{
 
                 UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
                     SeatStatus.RESERVED);
-                seatClient.updateStatusInternal(command);
+                seatClient.updateStatusInternal(ticket.getUserId(), UserRole.USER,command);
             }else{
                 List<UUID> seatIds = new ArrayList<>();
                 seatIds.add(ticket.getSeatId());
 
                 UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
                     SeatStatus.AVAILABLE);
-                seatClient.updateStatusInternal(command);
+                seatClient.updateStatusInternal(ticket.getUserId(), UserRole.USER,
+                    command);
 
             }
             ticket.updateTicketStatus(newStatus);

--- a/ticket/src/main/java/com/onevoice/ticket/domain/Ticket.java
+++ b/ticket/src/main/java/com/onevoice/ticket/domain/Ticket.java
@@ -1,6 +1,7 @@
 package com.onevoice.ticket.domain;
 
 import com.onevoice.common.entity.BaseEntity;
+import com.onevoice.common.enumtype.TicketStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,11 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name ="p_tickets")
+@Table(
+    name ="p_tickets",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_session_seat", columnNames = {"session_id", "seat_id"})
+    })
 public class Ticket extends BaseEntity {
 
     @Id
@@ -41,6 +46,10 @@ public class Ticket extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TicketStatus status;
 
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     public Ticket(UUID userId,String userName, UUID sessionId,String showName, UUID seatId) {
         this.userId = userId;
         this.userName = userName;
@@ -48,6 +57,7 @@ public class Ticket extends BaseEntity {
         this.showName = showName;
         this.seatId = seatId;
         this.reservedAt = LocalDateTime.now();
+        this.status = TicketStatus.WAITING_PAYMENT;
     }
 
     public void updateTicketStatus(TicketStatus status) {

--- a/ticket/src/main/java/com/onevoice/ticket/exception/DuplicateTicketException.java
+++ b/ticket/src/main/java/com/onevoice/ticket/exception/DuplicateTicketException.java
@@ -1,0 +1,11 @@
+package com.onevoice.ticket.exception;
+
+import com.onevoice.common.dto.ResponseCode;
+import com.onevoice.common.exception.BaseException;
+
+public class DuplicateTicketException extends BaseException {
+    public DuplicateTicketException(){
+        super(ResponseCode.DUPLICATE_TICKET_EXCEPTION);
+    }
+
+}

--- a/ticket/src/main/java/com/onevoice/ticket/exception/TicketSessionNotFoundException.java
+++ b/ticket/src/main/java/com/onevoice/ticket/exception/TicketSessionNotFoundException.java
@@ -5,7 +5,7 @@ import com.onevoice.common.exception.BaseException;
 
 public class TicketSessionNotFoundException extends BaseException {
     public TicketSessionNotFoundException(){
-        super(ResponseCode.Ticket_SESSION_NOT_FOUND);
+        super(ResponseCode.TICKET_SESSION_NOT_FOUND);
     }
 
 }

--- a/ticket/src/main/java/com/onevoice/ticket/infrastructure/config/KafkaConfig.java
+++ b/ticket/src/main/java/com/onevoice/ticket/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,35 @@
+package com.onevoice.ticket.infrastructure.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+public class KafkaConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        ConsumerFactory<String, String> consumerFactory,
+        KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        // 실패한 메시지를 <원래토픽명>.DLQ 로 전송
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            (record, ex) -> new TopicPartition(record.topic() + ".DLQ", record.partition())
+        );
+
+        // 최대 3번 재시도 후 DLQ로 이동
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+
+}

--- a/ticket/src/main/java/com/onevoice/ticket/infrastructure/config/RedisConfig.java
+++ b/ticket/src/main/java/com/onevoice/ticket/infrastructure/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.onevoice.ticket.infrastructure.config;
+
+import com.onevoice.common.config.manualConfig.RedisSupportFactory;
+
+import com.onevoice.common.config.manualConfig.RedissonSupportFactory;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private static String REDIS_HOST;
+
+    @Value("${redis.port}")
+    private static int REDIS_PORT;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return RedisSupportFactory.redisConnectionFactory(REDIS_HOST, REDIS_PORT);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        return RedisSupportFactory.redisTemplate(factory);
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        return RedissonSupportFactory.create(REDIS_HOST,REDIS_PORT);
+    }
+
+}

--- a/ticket/src/main/java/com/onevoice/ticket/infrastructure/message/TicketDlqConsumer.java
+++ b/ticket/src/main/java/com/onevoice/ticket/infrastructure/message/TicketDlqConsumer.java
@@ -1,0 +1,19 @@
+package com.onevoice.ticket.infrastructure.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TicketDlqConsumer {
+
+    @KafkaListener(topics = "ticket_status.DLQ", groupId = "ticket-dlq-group")
+    public void consumeDlq(ConsumerRecord<String, String> record) {
+        log.error("[DLQ] Failed message received: topic={}, partition={}, offset={}, key={}, value={}",
+            record.topic(), record.partition(), record.offset(), record.key(), record.value());
+
+        // 필요 시 file 또는 DB 저장도??
+    }
+}

--- a/ticket/src/main/java/com/onevoice/ticket/infrastructure/message/TicketStatusMessageConsumer.java
+++ b/ticket/src/main/java/com/onevoice/ticket/infrastructure/message/TicketStatusMessageConsumer.java
@@ -1,0 +1,40 @@
+package com.onevoice.ticket.infrastructure.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onevoice.common.enumtype.TicketStatus;
+import com.onevoice.ticket.application.dto.TicketMessage;
+import com.onevoice.ticket.application.service.TicketService;
+import com.onevoice.ticket.presentation.dto.request.UpdateTicketStatusRequestDto;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TicketStatusMessageConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final TicketService ticketService;
+
+    @KafkaListener(topics = "ticket_status", groupId = "ticket-group")
+    public void consume(ConsumerRecord<String, String> record) {
+        String value = record.value();
+        try {
+            TicketMessage message = objectMapper.readValue(value, TicketMessage.class);
+            log.info("Received ticket status update: {}", message);
+
+            ticketService.updateTicketStatus(
+                message.ticketId(),
+                new UpdateTicketStatusRequestDto(TicketStatus.valueOf(message.ticketStatus().name())));
+
+        } catch (IOException e) {
+            log.error("Failed to parse ticket status message", e);
+        } catch (Exception e) {
+            log.error("Failed to update ticket status", e);
+        }
+    }
+}

--- a/ticket/src/main/java/com/onevoice/ticket/presentation/dto/request/UpdateTicketStatusRequestDto.java
+++ b/ticket/src/main/java/com/onevoice/ticket/presentation/dto/request/UpdateTicketStatusRequestDto.java
@@ -1,6 +1,6 @@
 package com.onevoice.ticket.presentation.dto.request;
 
-import com.onevoice.ticket.domain.TicketStatus;
+import com.onevoice.common.enumtype.TicketStatus;
 
 public record UpdateTicketStatusRequestDto(
         TicketStatus status

--- a/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/FindTicketResponseDto.java
+++ b/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/FindTicketResponseDto.java
@@ -1,7 +1,7 @@
 package com.onevoice.ticket.presentation.dto.response;
 
+import com.onevoice.common.enumtype.TicketStatus;
 import com.onevoice.ticket.domain.Ticket;
-import com.onevoice.ticket.domain.TicketStatus;
 
 import java.time.LocalDateTime;
 import java.util.UUID;


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : #63 

<!---해결할 관련된 이슈 번호를 작성해주세요 (예: #123). -->

- ticket 동시성 제어 (낙관적 락 / redisson을 활용한 락은 seat에서 하고 있어서 일단 적용 x)
- kafka리스너 적용
- kafka 토픽 수신 시 , 헤더에 인증정보가 없어서 403오류 발생 -> 일단은 내부 호출하는 API에 @RequestHeader를 사용하여 인증 정보 저장 

## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

- SAGA패턴 적용도 고려해야 하는데, 지금은 서비스간 결합도가 너무 강한거 같아서 빠르게 적용하는걸 생각해봐야 할 거 같아요.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
