### PR TITLE
Feature/#83 feat ticket additional feature

### DIFF
--- a/show/src/main/java/com/onevoice/show/application/service/session/SessionServiceImpl.java
+++ b/show/src/main/java/com/onevoice/show/application/service/session/SessionServiceImpl.java
@@ -186,9 +186,13 @@ public class SessionServiceImpl implements SessionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public SessionDetailResponseDto getSessionDetail(UUID sessionId) {
         Session session = sessionRepository.findById(sessionId)
             .orElseThrow(NotFoundSessionException::new);
+
+        // Lazy 초기화
+        session.getShow().getId();
 
         return SessionDetailResponseDto.of(session);
     }

--- a/ticket/src/main/java/com/onevoice/ticket/application/dto/TicketConfirmedMessage.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/dto/TicketConfirmedMessage.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 public record TicketConfirmedMessage(
-    List<UUID> seatId,
+    List<UUID> seatIds,
     UUID userId
 ) {
 

--- a/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
+++ b/ticket/src/main/java/com/onevoice/ticket/application/service/TicketServiceImpl.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -70,7 +69,7 @@ public class TicketServiceImpl implements TicketService{
             String showName = sessionQuery.showName();
 
             // 3. 좌석 선점 요청
-            List<UUID> seatIdList = List.of(requestDto.seatId());
+            List<UUID> seatIdList = requestDto.seatIds();
             HoldSeatCommand holdCommand = new HoldSeatCommand(seatIdList);
 
             seatClient.holdSeatsInternal(requestDto.sessionId(), holdCommand)
@@ -82,7 +81,7 @@ public class TicketServiceImpl implements TicketService{
                 userName,
                 requestDto.sessionId(),
                 showName,
-                requestDto.seatId()
+                requestDto.seatIds()
             );
             Ticket saved = ticketRepository.save(ticket);
 
@@ -118,6 +117,9 @@ public class TicketServiceImpl implements TicketService{
 
             throw new TicketOwnerMismatchException();
         }
+
+        // Lazy 초기화
+        ticket.getSeatIdList().size();
         return FindTicketResponseDto.of(ticket);
     }
 
@@ -161,15 +163,13 @@ public class TicketServiceImpl implements TicketService{
             }
 
             if (newStatus == TicketStatus.CONFIRM_PAYMENT) {
-                List<UUID> seatIds = new ArrayList<>();
-                seatIds.add(ticket.getSeatId());
+                List<UUID> seatIds = ticket.getSeatIdList();
 
                 UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
                     SeatStatus.RESERVED);
                 seatClient.updateStatusInternal(ticket.getUserId(), UserRole.USER,command);
             }else{
-                List<UUID> seatIds = new ArrayList<>();
-                seatIds.add(ticket.getSeatId());
+                List<UUID> seatIds = ticket.getSeatIdList();
 
                 UpdateSeatStatusCommand command = new UpdateSeatStatusCommand(seatIds,
                     SeatStatus.AVAILABLE);
@@ -245,8 +245,7 @@ public class TicketServiceImpl implements TicketService{
 
         // 티켓 상태 변경
         ticket.updateTicketStatus(newStatus);
-        List<UUID> seatIdList = new ArrayList<>();
-        seatIdList.add(ticket.getSeatId());
+        List<UUID> seatIdList = ticket.getSeatIdList();
 
         // 좌석 확정 메시지 발행
         TicketConfirmedMessage payload = new TicketConfirmedMessage(seatIdList, ticket.getUserId());
@@ -269,8 +268,7 @@ public class TicketServiceImpl implements TicketService{
 
         // 티켓 상태 변경
         ticket.updateTicketStatus(newStatus);
-        List<UUID> seatIdList = new ArrayList<>();
-        seatIdList.add(ticket.getSeatId());
+        List<UUID> seatIdList = ticket.getSeatIdList();
 
         // 티켓 확정 실패 메시지 발행
         TicketFailedMessage payload = new TicketFailedMessage(seatIdList, ticket.getUserId());

--- a/ticket/src/main/java/com/onevoice/ticket/domain/Ticket.java
+++ b/ticket/src/main/java/com/onevoice/ticket/domain/Ticket.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 
@@ -36,8 +37,10 @@ public class Ticket extends BaseEntity {
     @Column(name = "show_name",nullable = false)
     private String showName;
 
+    @ElementCollection
+    @CollectionTable(name = "ticket_seat_ids", joinColumns = @JoinColumn(name = "ticket_id"))
     @Column(name = "seat_id", nullable = false)
-    private UUID seatId;
+    private List<UUID> seatIdList;
 
     @Column(name = "reserved_at")
     private LocalDateTime reservedAt;
@@ -50,12 +53,12 @@ public class Ticket extends BaseEntity {
     @Column(name = "version")
     private Long version;
 
-    public Ticket(UUID userId,String userName, UUID sessionId,String showName, UUID seatId) {
+    public Ticket(UUID userId,String userName, UUID sessionId,String showName, List<UUID> seatIds) {
         this.userId = userId;
         this.userName = userName;
         this.sessionId = sessionId;
         this.showName = showName;
-        this.seatId = seatId;
+        this.seatIdList = seatIds;
         this.reservedAt = LocalDateTime.now();
         this.status = TicketStatus.WAITING_PAYMENT;
     }

--- a/ticket/src/main/java/com/onevoice/ticket/infrastructure/TicketRepositoryImpl.java
+++ b/ticket/src/main/java/com/onevoice/ticket/infrastructure/TicketRepositoryImpl.java
@@ -48,6 +48,7 @@ public class TicketRepositoryImpl implements TicketRepository {
 
         Long total = queryFactory
                 .select(ticket.count())
+                .from(ticket)
                 .where(ticket.userId.eq(userID),
                         ticket.deletedAt.isNull())
                 .fetchOne();
@@ -72,6 +73,7 @@ public class TicketRepositoryImpl implements TicketRepository {
 
         Long toal = queryFactory
                 .select(ticket.count())
+                .from(ticket)
                 .where(ticket.showName.containsIgnoreCase(keyword),
                         ticket.deletedAt.isNull())
                 .fetchOne();
@@ -102,12 +104,11 @@ public class TicketRepositoryImpl implements TicketRepository {
                 case "userid" -> orderSpecifiers.add(new OrderSpecifier<>(direction, ticket.userId));
                 case "sessionid" -> orderSpecifiers.add(new OrderSpecifier<>(direction, ticket.sessionId));
                 case "showname" ->orderSpecifiers.add(new OrderSpecifier<>(direction,ticket.showName));
-                case "seatid" -> orderSpecifiers.add(new OrderSpecifier<>(direction, ticket.seatId));
                 case "status" -> orderSpecifiers.add(new OrderSpecifier<>(direction, ticket.status));
                 default -> throw new IllegalArgumentException("정렬 불가능한 필드: "+property+ "\n"
-                        + "정렬 가능한 필드들 리스트 : createdAt,createdBy,userId,sessionId,showName,seatId,status");
+                        + "정렬 가능한 필드들 리스트 : createdAt,createdBy,userId,sessionId,showName,status");
             }
         }
-        return null;
+        return orderSpecifiers;
     }
 }

--- a/ticket/src/main/java/com/onevoice/ticket/presentation/dto/request/CreateTicketRequestDto.java
+++ b/ticket/src/main/java/com/onevoice/ticket/presentation/dto/request/CreateTicketRequestDto.java
@@ -1,10 +1,11 @@
 package com.onevoice.ticket.presentation.dto.request;
 
+import java.util.List;
 import java.util.UUID;
 
 public record CreateTicketRequestDto(
         UUID userId,
         UUID sessionId,
-        UUID seatId
+        List<UUID> seatIds
 ) {
 }

--- a/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/CreateTicketResponseDto.java
+++ b/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/CreateTicketResponseDto.java
@@ -2,6 +2,7 @@ package com.onevoice.ticket.presentation.dto.response;
 
 import com.onevoice.ticket.domain.Ticket;
 
+import java.util.List;
 import java.util.UUID;
 
 public record CreateTicketResponseDto(
@@ -10,9 +11,9 @@ public record CreateTicketResponseDto(
         String userName,
         UUID showId,
         String showName,
-        UUID seatId
+        List<UUID> seatId
 ) {
     public static CreateTicketResponseDto of(Ticket ticket) {
-        return new CreateTicketResponseDto(ticket.getId(), ticket.getUserId(), ticket.getUserName() , ticket.getSessionId(), ticket.getShowName(), ticket.getSeatId());
+        return new CreateTicketResponseDto(ticket.getId(), ticket.getUserId(), ticket.getUserName() , ticket.getSessionId(), ticket.getShowName(), ticket.getSeatIdList());
     }
 }

--- a/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/FindTicketResponseDto.java
+++ b/ticket/src/main/java/com/onevoice/ticket/presentation/dto/response/FindTicketResponseDto.java
@@ -4,6 +4,7 @@ import com.onevoice.common.enumtype.TicketStatus;
 import com.onevoice.ticket.domain.Ticket;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record FindTicketResponseDto(
@@ -12,11 +13,11 @@ public record FindTicketResponseDto(
         String userName,
         UUID showId,
         String showName,
-        UUID seatId,
+        List<UUID> seatId,
         TicketStatus status,
         LocalDateTime reservedAt
 ) {
     public static FindTicketResponseDto of(Ticket ticket) {
-        return new FindTicketResponseDto(ticket.getId(), ticket.getUserId(), ticket.getUserName() ,ticket.getSessionId(),ticket.getShowName() ,ticket.getSeatId(), ticket.getStatus(), ticket.getReservedAt());
+        return new FindTicketResponseDto(ticket.getId(), ticket.getUserId(), ticket.getUserName() ,ticket.getSessionId(),ticket.getShowName() ,ticket.getSeatIdList(), ticket.getStatus(), ticket.getReservedAt());
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : #83 

<!---해결할 관련된 이슈 번호를 작성해주세요 (예: #123). -->

## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

- Ticket 생성 시 좌석을 한번에 여러개 등록할 수 있도록 변경
- Ticket엔티티의 seatId필드를 List로 변경
  -> 그에 따라 seatIds필드에  @ElementCollection,@CollectionTable어노테이션 적용 
  -> ticket엔티티의 seat필드를 List로 변경함에 따라 생기는 Lazy초기화 Exception이슈 해결을 위해 Transactional안에서 임의로 lazy초기화 수행"
- Ticket엔티티 조회 쿼리 실행 시, from이 누락되었던 것 추가

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

- .LazyInitializationException발생하는것이 몇 개 있습니다. 제가 발견한 부분은 수정했습니다. Show도메인에 getSessionDetail도 발생하길래 @Transactional어노테이션 추가했습니다... 여태 잘 되다가 갑자기 왜 그러는지 모르겠는데 검색해보니 그럴 수도 있다고 하네요? hibernate에서 지연로딩 된 객체에 접근하려고 할 때, 세션이 이미 닫혀있어 접근할 수 없는 상황이 생긴다고 합니다.

    1. Hibernate 세션이 닫혔고 (예: 트랜잭션 종료)

    2. 그 이후에 Lazy 객체에 접근하려고 하면 (예: .toString() 호출 등)

    3. Hibernate는 더 이상 DB에 접근할 수 없으니 예외를 던짐

- **좌석 TTL 만료 시 이벤트를 발행해서 Ticket과 payment를 실패하는 로직을 추가할 필요가 있는 것 같습니다. 지금은 TTL이 만료되어 좌석 선점이 해제되어도 결제가 성공하면 그대로 해당 좌석을 얻을 수 있네요**

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
