### PR TITLE
Feature/#95 feat seat expired publish

### DIFF
--- a/common/src/main/java/com/onevoice/common/enumtype/KafkaTopicType.java
+++ b/common/src/main/java/com/onevoice/common/enumtype/KafkaTopicType.java
@@ -16,7 +16,6 @@ public enum KafkaTopicType {
     TICKET_CANCEL("ticket_cancel"),
 
     SEAT_CONFIRM("seat_confirm"),
-    SEAT_CONFIRM_FAIL("seat_confirm_fail"),
     SEAT_CANCEL("seat_cancel"),
     SEAT_CREATE_REQUEST("seat_create_request"),
     SEAT_EXPIRED("seat_expired"),

--- a/seat/src/main/java/com/onevoice/seat/application/dto/message/SeatExpiredMessage.java
+++ b/seat/src/main/java/com/onevoice/seat/application/dto/message/SeatExpiredMessage.java
@@ -1,0 +1,7 @@
+package com.onevoice.seat.application.dto.message;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SeatExpiredMessage(List<UUID> seatIds, UUID userId) {
+}

--- a/seat/src/main/java/com/onevoice/seat/application/service/SeatServiceImpl.java
+++ b/seat/src/main/java/com/onevoice/seat/application/service/SeatServiceImpl.java
@@ -141,7 +141,7 @@ public class SeatServiceImpl implements SeatService {
         SessionId sessionId = new SessionId(command.sessionId());
         List<UUID> seatIdList = command.seatIds();
         UUID userId = command.userId();
-
+        LocalDateTime expireAt = LocalDateTime.now().plusMinutes(5);
 
         //좌석 조회
         List<Seat> seats = seatIdList.stream()
@@ -177,8 +177,10 @@ public class SeatServiceImpl implements SeatService {
                 }
 
                 redisTemplate.opsForHash().put(redisKey, seatIdStr, "HOLD");
-                redisTemplate.opsForValue().set(holdKey, userId.toString(), Duration.ofMinutes(5));
-                log.info("[{}] 선점 성공 → 상태: HOLD, TTL 5분 설정 완료", seatIdStr);
+                // 문자열: userId,expireAt 저장 (TTL x)
+                String redisValue = userId + "," + expireAt;
+                redisTemplate.opsForValue().set(holdKey, redisValue);
+                log.info("[{}] 선점 성공 → 상태: HOLD", seatIdStr);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.error("[{}] 락 대기 중 인터럽트 발생", seatIdStr, e);
@@ -192,7 +194,7 @@ public class SeatServiceImpl implements SeatService {
             }
         }
         redisTemplate.delete(RedisKeyUtil.seatCacheKey(sessionId.getValue()));
-        return HoldSeatResponseDto.success(LocalDateTime.now().plusMinutes(5), seatIdList);
+        return HoldSeatResponseDto.success(expireAt, seatIdList);
 
     }
 

--- a/seat/src/main/java/com/onevoice/seat/infrastructure/message/SeatEventProducer.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/message/SeatEventProducer.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onevoice.common.enumtype.KafkaTopicType;
 import com.onevoice.seat.application.dto.message.SeatCreateFailMessage;
 import com.onevoice.seat.application.dto.message.SeatCreateSuccessMessage;
+
+import java.util.List;
 import java.util.UUID;
+
+import com.onevoice.seat.application.dto.message.SeatExpiredMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -45,4 +49,21 @@ public class SeatEventProducer {
             log.error("seat_create_fail 전송 실패", e);
         }
     }
+
+    /*
+    * 좌석 만료
+    * */
+    public void sendSeatExpired(List<UUID> seatIds, UUID userId) {
+
+        try{
+            SeatExpiredMessage message = new SeatExpiredMessage(seatIds, userId);
+            String jsonMessage = objectMapper.writeValueAsString(message);
+            kafkaTemplate.send(KafkaTopicType.SEAT_EXPIRED.getTopic(), userId.toString(), jsonMessage);
+            log.info("seat_expired 전송 완료: {}", jsonMessage);
+        }catch (Exception e) {
+            log.error("seat_expired 전송 실패", e);
+        }
+
+    }
+
 }

--- a/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Slf4j
@@ -17,7 +18,7 @@ public class SeatHoldRecoveryScheduler {
     private final StringRedisTemplate redisTemplate;
     private final SeatEventProducer seatEventProducer;
 
-    @Scheduled(fixedDelay = 300_000) // 5분마다
+    @Scheduled(fixedDelay = 60_000) //1분마다
     public void recoverExpiredHolds() {
         log.info("TTL 만료 좌석 복구 스케쥴러 실행");
         Set<String> keys = redisTemplate.keys("seat:*");
@@ -28,14 +29,7 @@ public class SeatHoldRecoveryScheduler {
             String[] parts = redisKey.split(":");
             if (parts.length != 2) continue;
 
-            UUID sessionId;
-            try {
-                sessionId = UUID.fromString(parts[1]);
-            } catch (IllegalArgumentException e) {
-                log.warn("잘못된 세션 키 형식: {}", redisKey);
-                continue;
-            }
-
+            UUID sessionId = UUID.fromString(parts[1]);
             //좌석별 상태 확인
             Map<Object, Object> seatStatusMap = redisTemplate.opsForHash().entries(redisKey);
 
@@ -48,34 +42,41 @@ public class SeatHoldRecoveryScheduler {
             for (Map.Entry<Object, Object> entry : seatStatusMap.entrySet()) {
                 String seatIdStr = (String) entry.getKey();
                 String status = (String) entry.getValue();
+                if (!"HOLD".equals(status)) continue;
+                UUID seatId = UUID.fromString(seatIdStr);
+                String holdKey = RedisKeyUtil.seatHoldKey(sessionId, seatId);
+                String raw = redisTemplate.opsForValue().get(holdKey);
 
-                if ("HOLD".equals(status)) {
-                    UUID seatId = UUID.fromString(seatIdStr);
-                    String holdKey = RedisKeyUtil.seatHoldKey(sessionId, seatId);
+                if (raw == null) continue;
 
-                    //삭제 전 userId 먼저 조회
-                    String userIdStr = redisTemplate.opsForValue().get(holdKey);
-                    Boolean stillExists = redisTemplate.hasKey(holdKey);
-                    if (Boolean.FALSE.equals(stillExists)) {
+                try {
+                    String[] parts2 = raw.split(",", 2);
+                    UUID userId = UUID.fromString(parts2[0]);
+                    LocalDateTime expireAt = LocalDateTime.parse(parts2[1]);
+
+                    boolean expired = LocalDateTime.now().isAfter(expireAt);
+                    log.info("[{}] 복구 체크 - now={}, expireAt={}, expired={}", seatId, LocalDateTime.now(), expireAt, expired);
+
+                    if (expired) {
                         redisTemplate.opsForHash().put(redisKey, seatIdStr, "AVAILABLE");
-                        log.info("TTL 만료 → [{}] 상태 복구 완료 (sessionId: {})", seatId, sessionId);
+                        redisTemplate.delete(holdKey);
+                        log.info("[{}] 만료됨 → 상태 복구 완료", seatId);
 
-                        if(userIdStr != null) {
-                            UUID userId = UUID.fromString(userIdStr);
-                            if (!expiredSeatsByUser.containsKey(userId)) {
-                                expiredSeatsByUser.put(userId, new ArrayList<>());
-                            }
-                            expiredSeatsByUser.get(userId).add(seatId);
-                        }
+                        expiredSeatsByUser
+                                .computeIfAbsent(userId, k -> new ArrayList<>())
+                                .add(seatId);
                     }
+                } catch (Exception e) {
+                    log.warn("복구 파싱 실패: key={}, value={}", holdKey, raw, e);
                 }
             }
+
             // Kafka 발행
             for (Map.Entry<UUID, List<UUID>> entry : expiredSeatsByUser.entrySet()) {
                 UUID userId = entry.getKey();
                 List<UUID> expiredSeats = entry.getValue();
-
                 seatEventProducer.sendSeatExpired(expiredSeats, userId);
+                log.info("Kafka 발행 완료 - userId={}, expiredSeats={}", userId, expiredSeats);
             }
         }
     }

--- a/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
@@ -40,7 +40,7 @@ public class SeatHoldRecoveryScheduler {
             Map<Object, Object> seatStatusMap = redisTemplate.opsForHash().entries(redisKey);
 
 
-            // userId → 만료된 seatId 리스트
+            //userId → 만료된 seatId 리스트
             //각 사용자마다 만료된 좌석들 모아두는 자료구조
             Map<UUID, List<UUID>> expiredSeatsByUser = new HashMap<>();
 
@@ -53,13 +53,13 @@ public class SeatHoldRecoveryScheduler {
                     UUID seatId = UUID.fromString(seatIdStr);
                     String holdKey = RedisKeyUtil.seatHoldKey(sessionId, seatId);
 
+                    //삭제 전 userId 먼저 조회
+                    String userIdStr = redisTemplate.opsForValue().get(holdKey);
                     Boolean stillExists = redisTemplate.hasKey(holdKey);
                     if (Boolean.FALSE.equals(stillExists)) {
                         redisTemplate.opsForHash().put(redisKey, seatIdStr, "AVAILABLE");
                         log.info("TTL 만료 → [{}] 상태 복구 완료 (sessionId: {})", seatId, sessionId);
 
-                        //userId 확인
-                        String userIdStr = redisTemplate.opsForValue().get(holdKey);
                         if(userIdStr != null) {
                             UUID userId = UUID.fromString(userIdStr);
                             if (!expiredSeatsByUser.containsKey(userId)) {

--- a/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/scheduler/SeatHoldRecoveryScheduler.java
@@ -1,5 +1,6 @@
 package com.onevoice.seat.infrastructure.scheduler;
 
+import com.onevoice.seat.infrastructure.message.SeatEventProducer;
 import com.onevoice.seat.infrastructure.redis.RedisKeyUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,15 +8,14 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class SeatHoldRecoveryScheduler {
     private final StringRedisTemplate redisTemplate;
+    private final SeatEventProducer seatEventProducer;
 
     @Scheduled(fixedDelay = 300_000) // 5분마다
     public void recoverExpiredHolds() {
@@ -39,6 +39,12 @@ public class SeatHoldRecoveryScheduler {
             //좌석별 상태 확인
             Map<Object, Object> seatStatusMap = redisTemplate.opsForHash().entries(redisKey);
 
+
+            // userId → 만료된 seatId 리스트
+            //각 사용자마다 만료된 좌석들 모아두는 자료구조
+            Map<UUID, List<UUID>> expiredSeatsByUser = new HashMap<>();
+
+
             for (Map.Entry<Object, Object> entry : seatStatusMap.entrySet()) {
                 String seatIdStr = (String) entry.getKey();
                 String status = (String) entry.getValue();
@@ -51,8 +57,25 @@ public class SeatHoldRecoveryScheduler {
                     if (Boolean.FALSE.equals(stillExists)) {
                         redisTemplate.opsForHash().put(redisKey, seatIdStr, "AVAILABLE");
                         log.info("TTL 만료 → [{}] 상태 복구 완료 (sessionId: {})", seatId, sessionId);
+
+                        //userId 확인
+                        String userIdStr = redisTemplate.opsForValue().get(holdKey);
+                        if(userIdStr != null) {
+                            UUID userId = UUID.fromString(userIdStr);
+                            if (!expiredSeatsByUser.containsKey(userId)) {
+                                expiredSeatsByUser.put(userId, new ArrayList<>());
+                            }
+                            expiredSeatsByUser.get(userId).add(seatId);
+                        }
                     }
                 }
+            }
+            // Kafka 발행
+            for (Map.Entry<UUID, List<UUID>> entry : expiredSeatsByUser.entrySet()) {
+                UUID userId = entry.getKey();
+                List<UUID> expiredSeats = entry.getValue();
+
+                seatEventProducer.sendSeatExpired(expiredSeats, userId);
             }
         }
     }


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : #95 



## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

<수정 전>
- KafkaTopicType에 SEAT_EXPIRED 추가
- 선점 만료 후 상태 복구 스케쥴링 코드에 seat_expired 발행 로직 추가

<수정 후>
- 1차 PR 올렸을 때 TTL 만료 시간과 스케쥴링 시간 사이의 간차가 생겨 그 사이에 선점 키를 삭제해버려서 userId를 찾지 못하는 문제가 발생 
-> kafka발행 안 됨 
- 이후 좌석 선점시 TTL 기반 자동 삭제 방식에서 벗어나 expireAt 정보를 직접 Redis에 저장하고 스케쥴러가 이를 기준으로 만료 여부를 판단하는 구조로 리팩토링

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어
1) Fallback에 대해서도 생각을 해봤는데 메시지 수신 받는 도메인에서 동일하게 Resilience4j을 적용하는 건 어떨까요??! 아니면 공통으로 빼거나..?
1. Retry 횟수 : 도메인마다 적절한 재시도 횟수 조정
2. Fallback 동작 : DLQ 발행 + 에러 저장...?
3. 지속적 실패 시 Circuit Breaker 활성화 

2) 처음엔 userId와 expireAt 필드를 갖는 객체로 저장을 하려고 했는데 Spring Redis + 직렬화 + Jackson 세팅이 얽히면서 실패하고 결국 문자열 저장방식으로 변경 했습니다... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 좌석 홀드 만료 시 사용자별 만료 알림 이벤트가 발송됩니다.

- **Refactor**
  - 좌석 만료 이벤트 관련 메시지 및 프로듀서 기능이 추가되었습니다.

- **Chores**
  - 사용되지 않는 토픽 타입이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->