### PR TITLE
Feature/#143 chore add swagger uri env

### DIFF
--- a/admin/k8s/deployment.yml
+++ b/admin/k8s/deployment.yml
@@ -51,3 +51,10 @@ spec:
                 secretKeyRef:
                   name: onevoice-secret
                   key: EUREKA_HOST
+
+            - name: SWAGGER_URL
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret
+

--- a/admin/k8s/deployment.yml
+++ b/admin/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: admin-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/admin/k8s/service-monitor.yml
+++ b/admin/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: admin-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: admin                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/admin/k8s/service.yml
+++ b/admin/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: admin-service
+  namespace: onevoice
 spec:
   selector:
     app: admin

--- a/auth/k8s/deployment.yml
+++ b/auth/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: auth-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:
@@ -17,6 +18,7 @@ spec:
           image: joon97/auth-service:latest  # Actions에서 sed로 SHA 버전으로 대체됨
           ports:
             - containerPort: 8001
+              name: auth-port
           env:
             - name: DB_HOST
               valueFrom:

--- a/auth/k8s/deployment.yml
+++ b/auth/k8s/deployment.yml
@@ -62,4 +62,7 @@ spec:
                   name: onevoice-secret
                   key: JWT_SECRET_KEY
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret

--- a/auth/k8s/service-monitor.yml
+++ b/auth/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: auth-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,8 +11,8 @@ spec:
       app: auth                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path
-      interval: 15s
+      interval: 30s

--- a/auth/k8s/service.yml
+++ b/auth/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: auth-service
+  namespace: onevoice
 spec:
   selector:
     app: auth

--- a/config/k8s/deployment.yml
+++ b/config/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: config-server
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/config/k8s/service.yml
+++ b/config/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: config-server
+  namespace: onevoice
 spec:
   selector:
     app: config

--- a/eureka/k8s/deployment.yml
+++ b/eureka/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eureka-server
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/eureka/k8s/service.yml
+++ b/eureka/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: eureka-server
+  namespace: onevoice
 spec:
   selector:
     app: eureka

--- a/gateway/k8s/deployment.yml
+++ b/gateway/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gateway-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:
@@ -17,6 +18,7 @@ spec:
           image: joon97/gateway-service:latest
           ports:
             - containerPort: 8080
+              name: gateway-port
           env:
             - name: CONFIG_SERVER_URL
               value: http://config-server:19000

--- a/gateway/k8s/service-monitor.yml
+++ b/gateway/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: gateway-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: gateway                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/gateway/k8s/service.yml
+++ b/gateway/k8s/service.yml
@@ -2,11 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gateway-service
+  namespace: onevoice
 spec:
   selector:
     app: gateway
   ports:
     - name: metrics
       port: 8080
-      targetPort: 8080
+      targetPort: gateway-port
   type: ClusterIP

--- a/notification/k8s/deployment.yml
+++ b/notification/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: notification-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/notification/k8s/deployment.yml
+++ b/notification/k8s/deployment.yml
@@ -91,7 +91,10 @@ spec:
                   key: DISCORD_WEBHOOK_URL
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret
 
             - name: KAFKA_PASSWORD
               valueFrom:

--- a/notification/k8s/service-monitor.yml
+++ b/notification/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: ntf-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: notification              # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/notification/k8s/service.yml
+++ b/notification/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: notification-service
+  namespace: onevoice
 spec:
   selector:
     app: notification

--- a/payment/k8s/deployment.yml
+++ b/payment/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/payment/k8s/deployment.yml
+++ b/payment/k8s/deployment.yml
@@ -80,4 +80,7 @@ spec:
                   name: onevoice-secret
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret

--- a/payment/k8s/service-monitor.yml
+++ b/payment/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: pay-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: payment                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/payment/k8s/service.yml
+++ b/payment/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: payment-service
+  namespace: onevoice
 spec:
   selector:
     app: payment

--- a/seat/k8s/deployment.yml
+++ b/seat/k8s/deployment.yml
@@ -59,7 +59,10 @@ spec:
                   key: KAFKA_HOST
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret
 
             - name: REDIS_HOST
               valueFrom:

--- a/seat/k8s/deployment.yml
+++ b/seat/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: seat-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/seat/k8s/service-monitor.yml
+++ b/seat/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: seat-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: seat                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/seat/k8s/service.yml
+++ b/seat/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: seat-service
+  namespace: onevoice
 spec:
   selector:
     app: seat

--- a/show/k8s/deployment.yml
+++ b/show/k8s/deployment.yml
@@ -59,7 +59,10 @@ spec:
                   key: KAFKA_HOST
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret
 
             - name: REDIS_HOST
               valueFrom:

--- a/show/k8s/deployment.yml
+++ b/show/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: show-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/show/k8s/service-monitor.yml
+++ b/show/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: show-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: show                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/show/k8s/service.yml
+++ b/show/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: show-service
+  namespace: onevoice
 spec:
   selector:
     app: show

--- a/ticket/k8s/deployment.yml
+++ b/ticket/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ticket-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/ticket/k8s/deployment.yml
+++ b/ticket/k8s/deployment.yml
@@ -71,7 +71,10 @@ spec:
                   name: onevoice-secret
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret
 
             - name: KAFKA_PASSWORD
               valueFrom:

--- a/ticket/k8s/service-monitor.yml
+++ b/ticket/k8s/service-monitor.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: ticket-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: ticket                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/ticket/k8s/service.yml
+++ b/ticket/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ticket-service
+  namespace: onevoice
 spec:
   selector:
     app: ticket

--- a/user/k8s/deployment.yml
+++ b/user/k8s/deployment.yml
@@ -53,4 +53,7 @@ spec:
                   key: EUREKA_HOST
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret

--- a/user/k8s/deployment.yml
+++ b/user/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/user/k8s/service-monitoring.yml
+++ b/user/k8s/service-monitoring.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: user-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: user                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/user/k8s/service.yml
+++ b/user/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: user-service
+  namespace: onevoice
 spec:
   selector:
     app: user

--- a/venue/k8s/deployment.yml
+++ b/venue/k8s/deployment.yml
@@ -53,4 +53,7 @@ spec:
                   key: EUREKA_HOST
 
             - name: SWAGGER_URL
-              value: "http://localhost:8080"
+              valueFrom:
+                secretKeyRef:
+                  key: SWAGGER_URL
+                  name: onevoice-secret

--- a/venue/k8s/deployment.yml
+++ b/venue/k8s/deployment.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: venue-service
+  namespace: onevoice
 spec:
   replicas: 1
   selector:

--- a/venue/k8s/service-monitoring.yml
+++ b/venue/k8s/service-monitoring.yml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: venue-service-monitor
+  namespace: monitoring
   labels:
     release: kube-prometheus-stack   # Prometheus Operator가 이걸 감지할 수 있는 라벨
 spec:
@@ -10,7 +11,7 @@ spec:
       app: venue                      # service의 selector와 일치해야 함
   namespaceSelector:
     matchNames:
-      - default                      # service가 있는 namespace
+      - onevoice                      # service가 있는 namespace
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path

--- a/venue/k8s/service.yml
+++ b/venue/k8s/service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: venue-service
+  namespace: onevoice
 spec:
   selector:
     app: venue


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : #143 

<!---해결할 관련된 이슈 번호를 작성해주세요 (예: #123). -->

## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

- swagger_url 환경변수 설정
- namespace 분리 

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 모든 서비스와 모니터링 리소스에 대해 네임스페이스가 명시적으로 지정되어, 서비스는 이제 `onevoice` 네임스페이스, 서비스 모니터 리소스는 `monitoring` 네임스페이스에 배포됩니다.
  - 여러 서비스의 환경 변수 `SWAGGER_URL`이 하드코딩 값에서 시크릿 값 참조로 변경되었습니다.
  - 일부 서비스의 포트 정의에 이름이 추가되었습니다.
  - 서비스 모니터가 모니터링할 네임스페이스가 `default`에서 `onevoice`로 변경되었습니다.
  - 일부 서비스 모니터의 스크랩 간격이 15초에서 30초로 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->