### PR TITLE
Feature/final monitoring 1

### DIFF
--- a/admin/k8s/service-monitor.yml
+++ b/admin/k8s/service-monitor.yml
@@ -15,4 +15,4 @@ spec:
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path
-      interval: 15s
+      interval: 30s

--- a/admin/k8s/service.yml
+++ b/admin/k8s/service.yml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: admin-service
   namespace: onevoice
+  labels:
+    app: admin
 spec:
   selector:
     app: admin

--- a/auth/k8s/service.yml
+++ b/auth/k8s/service.yml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: auth-service
   namespace: onevoice
+  labels:
+    app: auth
 spec:
   selector:
     app: auth

--- a/gateway/k8s/service-monitor.yml
+++ b/gateway/k8s/service-monitor.yml
@@ -15,4 +15,4 @@ spec:
   endpoints:
     - port: metrics                  # service에서 지정한 name과 반드시 일치
       path: /actuator/prometheus     # prometheus export path
-      interval: 15s
+      interval: 30s

--- a/gateway/k8s/service.yml
+++ b/gateway/k8s/service.yml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: gateway-service
   namespace: onevoice
+  labels:
+    app: gateway
 spec:
   selector:
     app: gateway

--- a/helm/monitoring/README.md
+++ b/helm/monitoring/README.md
@@ -17,6 +17,18 @@ helm install loki grafana/loki-stack \
   -n monitoring -f helm/monitoring/loki-values.yaml
 ```
 
+## Prometheus UI 외부 접속(Port-Forwarding)
+
+```bash
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090
+```
+
+## Grafana 외부 접속 (Port-Forwarding)
+
+```bash
+ kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+```
+
 ## Grafana 외부 접속 (LoadBalancer 설정)
 
 ```bash

--- a/helm/monitoring/grafana-values.yaml
+++ b/helm/monitoring/grafana-values.yaml
@@ -32,18 +32,14 @@ grafana:
 
   dashboards:
     default:
-      kubernetes-cluster:
-        gnetId: 315
-        revision: 2
+      kubernetes-pod-metrics:
+        gnetId: 747
+        revision: 1
         datasource: Prometheus
       loki-logs:
         gnetId: 13639
         revision: 1
         datasource: Loki
-      spring-boot:
-        gnetId: 17175
-        revision: 1
-        datasource: Prometheus
       prometheus-stats:
         gnetId: 3662
         revision: 2

--- a/helm/monitoring/loki-values.yaml
+++ b/helm/monitoring/loki-values.yaml
@@ -1,11 +1,7 @@
 loki:
   enabled: true
   persistence:
-    enabled: true
-    storageClassName: gp2         # Kops - AWS EBS(gp2)를 사용
-    accessModes:
-      - ReadWriteOnce
-    size: 10Gi                    # 초기에는 10Gi 정도로 시작 가능 (운영에 따라 조정)
+    enabled: false                 # 디스트 저장 비활성화
 
 promtail:
   enabled: true
@@ -14,4 +10,4 @@ promtail:
       - url: http://loki.monitoring.svc:3100/loki/api/v1/push
 
 grafana:
-  enabled: false
+  enabled: false                   # 이미 설치된 경우 false로 유지


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : 

<!---해결할 관련된 이슈 번호를 작성해주세요 (예: #123). -->

## 📄 설명

- Helm 변경 : grafana - 대시보드  변경, loki - 디스크 저장 비활성화, readme 추가(monitoring 사용방식 설명 추가)
- auth, admin, gateway : /k8s/service.yaml, service-monitoring.yaml 변경  - 매트릭 수집 시간 연장 및 pod 라벨 추가

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 노드 터질까봐 PR 나눠서 할 예정입니다ㅠㅠ!! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
    - Prometheus 및 Grafana UI에 외부에서 접근할 수 있도록 포트 포워딩 방법을 안내하는 내용을 문서에 추가하였습니다.
- **신규 기능**
    - Kubernetes 서비스(manifest)에 app 레이블(admin, auth, gateway)을 추가하였습니다.
- **버그 수정**
    - Prometheus ServiceMonitor의 메트릭 수집 주기를 15초에서 30초로 조정하였습니다.
- **설정 변경**
    - Grafana 기본 대시보드 구성을 변경하여 "kubernetes-pod-metrics" 대시보드를 추가하고, 기존 "kubernetes-cluster" 및 "spring-boot" 대시보드를 제거하였습니다.
    - Loki의 영속적 저장소(persistence) 설정을 비활성화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->