### PR TITLE
feat(#171): add dlq

### DIFF
--- a/notification/src/main/java/com/onevoice/notification/infrastructure/config/KafkaConfig.java
+++ b/notification/src/main/java/com/onevoice/notification/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,40 @@
+package com.onevoice.notification.infrastructure.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+public class KafkaConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        ConsumerFactory<String, String> consumerFactory,
+        KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            (record, ex) ->
+                new TopicPartition(
+                    record.topic() + ".DLQ",
+                    record.partition()
+                )
+        );
+
+        // 최대 3번 재시도 후 DLQ로 이동
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+            recoverer,
+            new FixedBackOff(1000L, 3L)
+        );
+        factory.setCommonErrorHandler(errorHandler);
+        return factory;
+    }
+}


### PR DESCRIPTION
- notification kafka dlq 추가

## #️⃣ Issue Number


> IssueNumber : #171 

<!---해결할 관련된 이슈 번호를 작성해주세요 (예: #123). -->

## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
리팩톤 수정사항입니다.
notification service에 kafka event DLQ 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Kafka 메시지 소비 시 자동 재시도 및 데드레터 큐(DLQ) 처리 기능이 추가되었습니다. 실패한 메시지는 최대 3회 재시도 후 별도의 DLQ 토픽으로 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->