### PR TITLE
feat(#176) : kafka 장애대응을 위한 dlq 추가

### DIFF
--- a/seat/src/main/java/com/onevoice/seat/infrastructure/config/KafkaConfig.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,35 @@
+package com.onevoice.seat.infrastructure.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConfig {
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+            ConsumerFactory<String, String> consumerFactory,
+            KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        // 실패한 메시지를 .DLQ 토픽으로 보냄
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> new TopicPartition(record.topic() + ".DLQ", record.partition())
+        );
+
+        // 3번 재시도 1초 간격 → 이후 DLQ
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+}

--- a/seat/src/main/java/com/onevoice/seat/infrastructure/message/SeatDlqConsumer.java
+++ b/seat/src/main/java/com/onevoice/seat/infrastructure/message/SeatDlqConsumer.java
@@ -1,0 +1,27 @@
+package com.onevoice.seat.infrastructure.message;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SeatDlqConsumer {
+    @KafkaListener(topics = "seat_create_request.DLQ", groupId = "seat-dlq-group")
+    public void consumeDlq(ConsumerRecord<String, String> record) {
+        log.error("[DLQ] 좌석 생성 요청 처리 실패 메시지 수신: topic={}, partition={}, offset={}, key={}, value={}",
+                record.topic(), record.partition(), record.offset(), record.key(), record.value());
+
+
+    }
+    @KafkaListener(topics = "ticket_confirm.DLQ", groupId = "seat-dlq-group")
+    public void consumeTicketConfirmDlq(ConsumerRecord<String, String> record) {
+        log.error("[DLQ] ticket_confirm 처리 실패: {}", record.value());
+    }
+
+    @KafkaListener(topics = "ticket_cancel.DLQ", groupId = "seat-dlq-group")
+    public void consumeTicketCancelDlq(ConsumerRecord<String, String> record) {
+        log.error("[DLQ] ticket_cancel 처리 실패: {}", record.value());
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number


> IssueNumber : 

#176

## 📄 설명

> PR에 대한 간략한 설명을 작성해주세요.
> 어떤 문제를 해결했는지, 새로운 기능을 추가했는지 등 내용을 자세히 기입해 주세요.

-seat 메시지 오류 처리를 위해 DLQ 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Kafka 메시지 처리 실패 시 자동으로 데드레터 큐(DLQ)로 이동하도록 설정이 추가되었습니다.
    - 좌석 생성, 티켓 확인, 티켓 취소 관련 DLQ 토픽의 메시지를 수신하고 실패 정보를 기록하는 기능이 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->